### PR TITLE
Log any errors with json

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -414,14 +414,7 @@ func (j jsonLog) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	return json.Marshal(struct {
-		Level   string         `json:"level"`
-		Time    string         `json:"time"`
-		Message string         `json:"message"`
-		Group   string         `json:"group,omitempty"`
-		Attrs   map[string]any `json:"attrs,omitempty"`
-		Pid     string         `json:"pid,omitempty"`
-	}{
+	return json.Marshal(jsonLog{
 		Level:   j.Level,
 		Time:    j.Time,
 		Message: j.Message,

--- a/handler.go
+++ b/handler.go
@@ -403,3 +403,30 @@ type jsonLog struct {
 	Attrs   map[string]any `json:"attrs,omitempty"`
 	Pid     string         `json:"pid,omitempty"`
 }
+
+func (j jsonLog) MarshalJSON() ([]byte, error) {
+	a := map[string]any{}
+	for key, value := range j.Attrs {
+		if err, ok := value.(error); ok {
+			a[key] = err.Error()
+		} else {
+			a[key] = value
+		}
+	}
+
+	return json.Marshal(struct {
+		Level   string         `json:"level"`
+		Time    string         `json:"time"`
+		Message string         `json:"message"`
+		Group   string         `json:"group,omitempty"`
+		Attrs   map[string]any `json:"attrs,omitempty"`
+		Pid     string         `json:"pid,omitempty"`
+	}{
+		Level:   j.Level,
+		Time:    j.Time,
+		Message: j.Message,
+		Group:   j.Group,
+		Attrs:   a,
+		Pid:     j.Pid,
+	})
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -3,6 +3,7 @@ package shandler_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -247,6 +248,18 @@ func TestErrorTags(t *testing.T) {
 	logger := slog.New(handler.NewHandler(handler.WithStdErr(&stderr), handler.WithErrorTag()))
 	logger.Error("test")
 	assert.Contains(t, stderr.String(), fmt.Sprintf("[ERROR] %s - test error_id=", now))
+}
+
+func TestSlogAnyErrorWithJsonOption(t *testing.T) {
+	var stderr bytes.Buffer
+	now := time.Now().Format(time.TimeOnly)
+	logger := slog.New(handler.NewHandler(
+		handler.WithStdErr(&stderr),
+		handler.WithJSON(),
+	))
+	err := errors.New("big error")
+	logger.Error("test", slog.Any("err", err))
+	assert.Equal(t, fmt.Sprintf(`{"level":"ERROR","time":"%s","message":"test","attrs":{"err":"big error"}}\n`, now), stderr.String())
 }
 
 func BenchmarkHandlers(b *testing.B) {


### PR DESCRIPTION
Currently if you log an error with `slog.Any("err", err)`, it prints as `"err": {}`. This updates the JSON handler logic to unwrap errors and print them as strings.